### PR TITLE
refactor: rename deprecated retry property maxAttempt to maxAttempts

### DIFF
--- a/src/test/resources/sanity-checks/all_surrealdb.yaml
+++ b/src/test/resources/sanity-checks/all_surrealdb.yaml
@@ -28,7 +28,7 @@ tasks:
     retry:
       type: constant
       interval: PT3S
-      maxAttempt: 20
+      maxAttempts: 20
 
   - id: create_alpha
     type: io.kestra.plugin.surrealdb.Query


### PR DESCRIPTION
Renames the deprecated retry property maxAttempt to maxAttempts